### PR TITLE
Make the `list` commands consistent in the CLI

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,4 +84,4 @@ DEPENDENCIES
   tty-table
 
 BUNDLED WITH
-   2.0.2
+   1.17.3

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The following commands will create and display the cluster `foo`:
 $ bin/flightattr cluster create --name foo
 
 # Find the cluster ID
-$ bin/flightattr cluster list
+$ bin/flightattr list-clusters
 ID        Name
 <foo-id>  foo
 
@@ -88,10 +88,13 @@ The following will list the groups and show the results from the parameter engin
 
 ```
 # List the groups
-$ bin/flightattr group list
+$ bin/flightattr list-groups
 
 # Limit the list to the foo cluster
-$ bin/flightattr group list --cluster foo
+$ bin/flightattr cluster list-groups --name foo
+
+# Equivalent to:
+$ bin/flightattr cluster list-groups <foo-id>
 
 # View the nodes group by name
 $ bin/flightattr group show --cluster foo nodes
@@ -130,10 +133,9 @@ The following can be used to view the nodes and parameters:
 
 ```
 # List all the nodes
-$ bin/flightattr node list
+$ bin/flightattr list-nodes
 
 # List all the nodes within the foo cluster (and equivalents):
-$ bin/flightattr node list --cluster foo
 $ bin/flightattr cluster list-nodes --name foo
 $ bin/flightattr cluster list-nodes <foo-id>
 

--- a/lib/nodeattr_client/cli.rb
+++ b/lib/nodeattr_client/cli.rb
@@ -40,7 +40,7 @@ require 'nodeattr_client/commands/groups'
 require 'nodeattr_client/commands/clusters'
 
 module NodeattrClient
-  VERSION = '0.1.1'
+  VERSION = '0.1.2'
 
   class CLI
     extend Commander::Delegates

--- a/lib/nodeattr_client/cli.rb
+++ b/lib/nodeattr_client/cli.rb
@@ -154,10 +154,9 @@ module NodeattrClient
         end
       end
 
-      command "#{type} list" do |c|
+      command "list-#{plural}" do |c|
         cli_syntax(c)
         c.summary = "Return all the #{plural}"
-        CLUSTER_OPT.call(c) unless type == 'cluster'
         action(c, klass, method: :list)
       end
 


### PR DESCRIPTION
The `cluster/group/node list` commands where weird as they had a different syntax to the rest of their commands. Instead they have been made top level `list-{nodes/groups/clusters}` commands