### PR TITLE
Remove the column specifying the cluster name

### DIFF
--- a/lib/nodeattr_client/cli.rb
+++ b/lib/nodeattr_client/cli.rb
@@ -41,7 +41,7 @@ require 'nodeattr_client/commands/clusters'
 require 'nodeattr_client/commands/list_cascades'
 
 module NodeattrClient
-  VERSION = '0.1.3'
+  VERSION = '0.1.4'
 
   class CLI
     extend Commander::Delegates

--- a/lib/nodeattr_client/commands/list_cascades.rb
+++ b/lib/nodeattr_client/commands/list_cascades.rb
@@ -35,20 +35,19 @@ module NodeattrClient
 
       LIST_TABLE = [
         ['ID',      ->(r) { r.id }],
-        ['Cluster', ->(r) { r.is_a?(Cluster) ? r.name : r.cluster.name }],
+        ['Type',    ->(r) { r.class.type.singularize }],
         ['Name',    ->(r) { r.name }],
-        ['Type',    ->(r) { r.class.type.singularize }]
       ]
 
       def node(id_or_name, cluster: nil)
         id = resolve_ids(id_or_name, cluster)
-        models = Cascades.includes(:cluster).where(node_id: id).all
+        models = Cascades.where(node_id: id).all
         list_cascades(models)
       end
 
       def group(id_or_name, cluster: nil)
         id = resolve_ids(id_or_name, cluster)
-        models = Cascades.includes(:cluster).where(group_id: id).all
+        models = Cascades.where(group_id: id).all
         list_cascades(models)
       end
 


### PR DESCRIPTION
This is redundent as the first entry is always the cluster and thus
contains the name